### PR TITLE
Fixed the command for cloning repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Before you begin, make sure you have the following prerequisites installed on yo
    Clone this repository to your local machine:
 
    ```
-   git clone https://github.com/yourusername/blog-website.git
+   git clone https://github.com/yourusername/blog_website.git
    ```
    
 2. **Navigate to the Project Directory**

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Before you begin, make sure you have the following prerequisites installed on yo
    Clone this repository to your local machine:
 
    ```
-   git clone https://github.com/yourusername/blog_website.git
+   git clone https://github.com/Kritika30032002/Blog_Website.git
    ```
    
 2. **Navigate to the Project Directory**


### PR DESCRIPTION
The Command line for cloning the repo should be blog_website. But it was blog-website. Please merge this and label gssoc on my PR

**Description**

This PR fixes #201 