### PR TITLE
Add links in sign up & sign in to toggle in-between them

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -465,3 +465,10 @@ body.dark-mode .moon-icon {
 .contact.dark-mode {
   box-shadow: 0 0 10px rgba(255, 255, 255, 0.36);
 } 
+.contact p {
+  margin: 15px 0px;
+}
+.contact a {
+  color: #169c7f;
+  font-weight: bold;
+}

--- a/views/signin.ejs
+++ b/views/signin.ejs
@@ -56,10 +56,12 @@
           border: none;
           border-radius: 4px;
           cursor: pointer;
+          margin-top: 10px;
         "
       >
         Sign In
       </button>
+      <p>Don't have an account? <a href="/signup"><u>Sign up</u></a></p>
     </form>
   </section>
 </main>

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -74,11 +74,13 @@
           border: none;
           border-radius: 4px;
           cursor: pointer;
+          margin-top: 10px;
         "
       >
         Sign Up
       </button>
     </form>
+    <p>Already have an account? <a href="/signin"><u>Sign in</u></a></p>
   </section>
 </main>
 


### PR DESCRIPTION
**Description**
I have added the links to move from sign up page to sign in page and vice-versa. It will help the users to easily toggle between signup page and signin page. 

This PR fixes #204 

@Kritika30032002 Plz review and accept the PR under gssoc-ext level 2 and hacktoberfest.

I have attached the screenshots for reference.
<img width="550" alt="signin" src="https://github.com/user-attachments/assets/131c862f-5aeb-4757-8407-4fb8b2a7676f">
<img width="550" alt="signup" src="https://github.com/user-attachments/assets/bd1b1d74-2468-44ff-b9ae-a42139a3923e">
